### PR TITLE
Feature/5 ci construction

### DIFF
--- a/.github/workflows/java-build-actions.yml
+++ b/.github/workflows/java-build-actions.yml
@@ -9,9 +9,6 @@ name: Java build test with gradle
 
 on:
   push:
-    paths:
-      - 'src/**'
-      - '**.gradle'
     branches:
       - main
       - 'feature/5-ci-construction' #todo delete if test is completed

--- a/.github/workflows/java-build-actions.yml
+++ b/.github/workflows/java-build-actions.yml
@@ -31,17 +31,22 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
 
-    # Configure Gradle for optimal use in GiHub Actions, including caching of downloaded dependencies.
-    # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
+      # Configure Gradle for optimal use in GiHub Actions, including caching of downloaded dependencies.
+      # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
         with:
           gradle-version: '8.5'
+
       - name: Setup Gradle Wrapper
         run: gradle wrapper
+
       - name: Build with Gradle Wrapper
         run: ./gradlew build
+
+      - name: Check current directory
+        run: ls -al
 
   dependency-submission:
     needs: build
@@ -57,6 +62,17 @@ jobs:
         with:
           java-version: '17'
           distribution: 'adopt'
+
+      - name: Check current directory info
+        run: ls -al
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
+        with:
+          gradle-version: '8.5'
+
+      - name: Setup Gradle Wrapper
+        run: gradle wrapper
 
       # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
       # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md

--- a/.github/workflows/java-build-actions.yml
+++ b/.github/workflows/java-build-actions.yml
@@ -22,10 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+
     steps:
-      - uses: actions/checkout@4
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@4
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'
@@ -43,6 +44,7 @@ jobs:
         run: ./gradlew build
 
   dependency-submission:
+    needs: build
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/java-build-actions.yml
+++ b/.github/workflows/java-build-actions.yml
@@ -1,0 +1,65 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+
+name: Java build test with gradle
+
+on:
+  push:
+    paths:
+      - 'src/**'
+      - '**.gradle'
+    branches:
+      - main
+      - 'feature/5**' #todo delete if test is completed
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build project
+    runs-on: ubuntu-latest
+    permissions:
+      content: read
+    steps:
+      - uses: actions/checkout@4
+      - name: Set up JDK 17
+        uses: actions/setup-java@4
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+    # Configure Gradle for optimal use in GiHub Actions, including caching of downloaded dependencies.
+    # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
+        with:
+          gradle-version: '8.5'
+      - name: Setup Gradle Wrapper
+        run: gradle wrapper
+      - name: Build with Gradle Wrapper
+        run: ./gradlew build
+
+  dependency-submission:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+      # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
+      # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0

--- a/.github/workflows/java-build-actions.yml
+++ b/.github/workflows/java-build-actions.yml
@@ -14,7 +14,7 @@ on:
       - '**.gradle'
     branches:
       - main
-      - 'feature/5**' #todo delete if test is completed
+      - 'feature/5-ci-construction' #todo delete if test is completed
   pull_request:
     branches:
       - main

--- a/.github/workflows/java-build-actions.yml
+++ b/.github/workflows/java-build-actions.yml
@@ -21,7 +21,7 @@ jobs:
     name: Build project
     runs-on: ubuntu-latest
     permissions:
-      content: read
+      contents: read
     steps:
       - uses: actions/checkout@4
       - name: Set up JDK 17

--- a/.github/workflows/java-build-actions.yml
+++ b/.github/workflows/java-build-actions.yml
@@ -1,17 +1,9 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
-
 name: Java build test with gradle
 
 on:
   push:
     branches:
-      - main
-      - 'feature/5-ci-construction' #todo delete if test is completed
+      - '**'
   pull_request:
     branches:
       - main
@@ -20,8 +12,8 @@ jobs:
   build:
     name: Build project
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    outputs:
+      build-output: ${{ steps.artifact-upload-step.outputs.artifact-id }}
 
     steps:
       - uses: actions/checkout@v4
@@ -31,50 +23,74 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
 
-      # Configure Gradle for optimal use in GiHub Actions, including caching of downloaded dependencies.
-      # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
-
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
         with:
           gradle-version: '8.5'
-
-      - name: Setup Gradle Wrapper
-        run: gradle wrapper
+          cache-read-only: false
 
       - name: Build with Gradle Wrapper
-        run: ./gradlew build
+        run: |
+          gradle wrapper
+          ./gradlew build
 
-      - name: Check current directory
-        run: ls -al
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        id: artifact-upload-step
+        with:
+          name: monitoring-build-result
+          #          path: ~/build-result/
+          path: ./build/
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+          overwrite: true
+
+  execution:
+    name: Execute project
+
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - env:
+          BUILD-OUTPUT: ${{ needs.build.outputs.build-output }}
+        run: echo "artifact id from previous job is $BUILD-OUTPUT"
+
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: monitoring-build-result
+          path: ./build/
+
+      - name: Execute server application
+        run: java -jar build/libs/aicare-monitoring-0.0.1-SNAPSHOT.jar
 
   dependency-submission:
-    needs: build
+    name: Dependency submission
 
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: write
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
+      - uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'
 
-      - name: Check current directory info
-        run: ls -al
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
-        with:
-          gradle-version: '8.5'
-
-      - name: Setup Gradle Wrapper
-        run: gradle wrapper
-
-      # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
-      # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
+        with:
+          gradle-version: 8.5

--- a/.github/workflows/java-build-actions.yml
+++ b/.github/workflows/java-build-actions.yml
@@ -9,14 +9,15 @@ on:
       - main
 
 jobs:
-  build:
+  build-project:
     name: Build project
     runs-on: ubuntu-latest
     outputs:
-      build-output: ${{ steps.artifact-upload-step.outputs.artifact-id }}
-
+      filename: ${{ steps.build-info.outputs.result }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout branch
+        uses: actions/checkout@v4
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -34,12 +35,18 @@ jobs:
           gradle wrapper
           ./gradlew build
 
+      - name: Extract version and root project name
+        id: build-info
+        run: |
+          VERSION=$(grep "^version" build.gradle | awk -F"'" '{print $2}')
+          ROOT_PROJECT=$(grep "^rootProject.name" settings.gradle | awk -F"'" '{print $2}')
+          echo "result=$ROOT_PROJECT-$VERSION" >> $GITHUB_OUTPUT
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         id: artifact-upload-step
         with:
           name: monitoring-build-result
-          #          path: ~/build-result/
           path: ./build/
           if-no-files-found: error
           retention-days: 1
@@ -49,22 +56,18 @@ jobs:
   execution:
     name: Execute project
 
-    needs: build
+    needs: build-project
     runs-on: ubuntu-latest
 
     steps:
-      - env:
-          BUILD-OUTPUT: ${{ needs.build.outputs.build-output }}
-        run: echo "artifact id from previous job is $BUILD-OUTPUT"
-
-      - uses: actions/checkout@v4
+      - name: Checkout branch
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'
-
 
       - name: Download artifact
         uses: actions/download-artifact@v4
@@ -73,19 +76,24 @@ jobs:
           path: ./build/
 
       - name: Execute server application
-        run: java -jar build/libs/aicare-monitoring-0.0.1-SNAPSHOT.jar
+        env:
+          FILENAME: ${{ needs.build-project.outputs.filename }}
+        run: java -jar build/libs/${{ env.FILENAME }}.jar
 
   dependency-submission:
-    name: Dependency submission
+    name: Submit dependency graph to github
 
-    needs: build
+    needs: build-project
     runs-on: ubuntu-latest
     permissions:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - name: Checkout branch
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'


### PR DESCRIPTION
### java-build-actions 추가
> java build, execution, insights/dependency-graph job 실행
- 대상: push하는 모든 branch, main PR
- job 실행 순서: build > (execution, dependency-submission)
- gradle/, gradlew 없이 모든 job 실행 -> build job에서 gradle cache, build 결과물 artifact로 업로드
- execution job: unit test 외에 통합테스트 자동화용으로 생성